### PR TITLE
feat: argocd-vault-provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           },
           {
             "id": "argocd-project"
+          },
+          {
+            "id": "argocd-vault-provider"
           }
         ]
   kubeconform:
@@ -54,6 +57,9 @@ jobs:
         [
           {
             "id": "service"
+          },
+          {
+            "id": "argocd-vault-provider"
           }
         ]
   opa:
@@ -84,6 +90,9 @@ jobs:
           },
           {
             "id": "argocd-project"
+          },
+          {
+            "id": "argocd-vault-provider"
           }
         ]
     secrets:

--- a/argocd-vault-provider/Chart.yaml
+++ b/argocd-vault-provider/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: argocd-project
+description: HELM chart containig a seed secret for an ArgoCD Vault Provider
+type: application
+icon: https://avatars.githubusercontent.com/u/35167581?s=400&u=ca5fdf8da213a9ab3edd83813b5f3491dea70f6c&v=4
+version: 0.1.0
+appVersion: 0.1.0

--- a/argocd-vault-provider/templates/secret.yaml
+++ b/argocd-vault-provider/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-avp-configuration
+  namespace: argocd
+type: Opaque
+stringData:
+  AVP_TYPE: {{ .Values.argocd.vaultProvider.type | quote }}
+  OP_CONNECT_TOKEN: {{ .Values.onepassword.connect.token | quote }}
+  OP_CONNECT_HOST: {{ .Values.onepassword.connect.host | quote }}

--- a/argocd-vault-provider/values.ci.yaml
+++ b/argocd-vault-provider/values.ci.yaml
@@ -1,0 +1,7 @@
+argocd:
+  vaultProvider: 1passwordconnect
+
+onepassword:
+  connect:
+    host: "https://onepassword.dev.cloud-tek.io"
+    token: "123123123"

--- a/argocd-vault-provider/values.ci.yaml
+++ b/argocd-vault-provider/values.ci.yaml
@@ -1,5 +1,6 @@
 argocd:
-  vaultProvider: 1passwordconnect
+  vaultProvider:
+    type: 1passwordconnect
 
 onepassword:
   connect:

--- a/argocd-vault-provider/values.yaml
+++ b/argocd-vault-provider/values.yaml
@@ -1,0 +1,7 @@
+argocd:
+  vaultProvider: 1passwordconnect
+
+onepassword:
+  connect:
+    host: <host>
+    token: <token>

--- a/argocd-vault-provider/values.yaml
+++ b/argocd-vault-provider/values.yaml
@@ -1,5 +1,6 @@
 argocd:
-  vaultProvider: 1passwordconnect
+  vaultProvider:
+    type: 1passwordconnect
 
 onepassword:
   connect:


### PR DESCRIPTION
This PR:
- Adds an argocd-vault-provider chart to seed AVP using HELM